### PR TITLE
Implement does-user-exists call

### DIFF
--- a/gocd-filebased-authentication-plugin/src/main/java/cd/go/authentication/passwordfile/PasswordFilePlugin.java
+++ b/gocd-filebased-authentication-plugin/src/main/java/cd/go/authentication/passwordfile/PasswordFilePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,8 @@ public class PasswordFilePlugin implements GoPlugin {
                     return new UserAuthenticationExecutor(request, new Authenticator()).execute();
                 case REQUEST_SEARCH_USERS:
                     return new SearchUserExecutor(request).execute();
+                case REQUEST_DOES_USER_EXISTS:
+                    return new DoesUserExistsExecutor(request).execute();
                 default:
                     throw new UnhandledRequestTypeException(request.requestName());
             }

--- a/gocd-filebased-authentication-plugin/src/main/java/cd/go/authentication/passwordfile/executor/DoesUserExistsExecutor.java
+++ b/gocd-filebased-authentication-plugin/src/main/java/cd/go/authentication/passwordfile/executor/DoesUserExistsExecutor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authentication.passwordfile.executor;
+
+import cd.go.authentication.passwordfile.PasswordFileReader;
+import cd.go.authentication.passwordfile.model.AuthConfig;
+import cd.go.authentication.passwordfile.model.User;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Properties;
+
+import static cd.go.authentication.passwordfile.utils.Util.GSON;
+
+public class DoesUserExistsExecutor implements RequestExecutor {
+    private final GoPluginApiRequest request;
+    private PasswordFileReader passwordFileReader;
+
+    public DoesUserExistsExecutor(GoPluginApiRequest request) {
+        this(request, new PasswordFileReader());
+    }
+
+    protected DoesUserExistsExecutor(GoPluginApiRequest request, PasswordFileReader passwordFileReader) {
+        this.request = request;
+        this.passwordFileReader = passwordFileReader;
+    }
+
+    @Override
+    public GoPluginApiResponse execute() throws Exception {
+        JsonObject jsonObject = GSON.fromJson(request.requestBody(), JsonObject.class);
+        Type type = new TypeToken<AuthConfig>() {}.getType();
+
+        String username = jsonObject.get("username").getAsString();
+        AuthConfig authConfig = GSON.fromJson(jsonObject.get("auth_config").toString(), type);
+
+        final User found = find(username, authConfig);
+
+        if (found != null) {
+            return new DefaultGoPluginApiResponse(200);
+        }
+
+        return new DefaultGoPluginApiResponse(404);
+    }
+
+    public User find(String username, AuthConfig authConfig) throws IOException {
+        final Properties properties = passwordFileReader.read(authConfig.getConfiguration().getPasswordFilePath());
+        return findUserNameContaining(username, properties);
+    }
+
+    private User findUserNameContaining(String usernameToFind, Properties properties) {
+        for (Object o : properties.keySet()) {
+            String username = (String) o;
+            if (username.toLowerCase().equalsIgnoreCase(usernameToFind.toLowerCase())) {
+                return new User(username, null, null);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/gocd-filebased-authentication-plugin/src/main/java/cd/go/authentication/passwordfile/executor/RequestFromServer.java
+++ b/gocd-filebased-authentication-plugin/src/main/java/cd/go/authentication/passwordfile/executor/RequestFromServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ public enum RequestFromServer {
     REQUEST_VERIFY_CONNECTION(String.join(".", Constants.REQUEST_PREFIX, Constants._AUTH_CONFIG_METADATA, "verify-connection")),
 
     REQUEST_AUTHENTICATE_USER(Constants.REQUEST_PREFIX + ".authenticate-user"),
-    REQUEST_SEARCH_USERS(Constants.REQUEST_PREFIX + ".search-users");
+    REQUEST_SEARCH_USERS(Constants.REQUEST_PREFIX + ".find-users"),
+
+    REQUEST_DOES_USER_EXISTS(Constants.REQUEST_PREFIX + ".does-user-exists");
 
     private final String requestName;
 

--- a/gocd-filebased-authentication-plugin/src/test/java/cd/go/authentication/passwordfile/executor/DoesUserExistsExecutorTest.java
+++ b/gocd-filebased-authentication-plugin/src/test/java/cd/go/authentication/passwordfile/executor/DoesUserExistsExecutorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authentication.passwordfile.executor;
+
+import cd.go.authentication.passwordfile.PasswordFileReader;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DoesUserExistsExecutorTest {
+
+    private PasswordFileReader fileReader;
+
+    @Before
+    public void setUp() throws Exception {
+        fileReader = mock(PasswordFileReader.class);
+    }
+
+    @Test
+    public void shouldReturn200WhenTheCurrentUserExistsInThePasswordFile() throws Exception {
+        final GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+
+        final Properties properties = new Properties();
+        properties.put("bob", "password1");
+        when(fileReader.read("/var/etc/password.properties")).thenReturn(properties);
+        when(request.requestBody()).thenReturn(requestJson("bob"));
+
+        final GoPluginApiResponse response = new DoesUserExistsExecutor(request, fileReader).execute();
+
+        assertThat(response.responseCode(), is(200));
+    }
+
+    @Test
+    public void shouldReturn404WhenTheCurrentUserDoesNotExistsInThePasswordFile() throws Exception {
+        final GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+
+        final Properties properties = new Properties();
+        properties.put("bob", "password1");
+        when(fileReader.read("/var/etc/password.properties")).thenReturn(properties);
+        when(request.requestBody()).thenReturn(requestJson("john"));
+
+        final GoPluginApiResponse response = new DoesUserExistsExecutor(request, fileReader).execute();
+
+        assertThat(response.responseCode(), is(404));
+    }
+
+    @Test
+    public void shouldLookForExactUsernameMatchInsteadOfRegExp() throws Exception {
+        final GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+
+        final Properties properties = new Properties();
+        properties.put("bobby", "password1");
+        when(fileReader.read("/var/etc/password.properties")).thenReturn(properties);
+        when(request.requestBody()).thenReturn(requestJson("bob"));
+
+        final GoPluginApiResponse response = new DoesUserExistsExecutor(request, fileReader).execute();
+
+        assertThat(response.responseCode(), is(404));
+    }
+
+    @Test
+    public void shouldLookForCaseInsensitiveUsernameMatch() throws Exception {
+        final GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+
+        final Properties properties = new Properties();
+        properties.put("bob", "password1");
+        when(fileReader.read("/var/etc/password.properties")).thenReturn(properties);
+        when(request.requestBody()).thenReturn(requestJson("BoB"));
+
+        final GoPluginApiResponse response = new DoesUserExistsExecutor(request, fileReader).execute();
+
+        assertThat(response.responseCode(), is(200));
+    }
+
+    private String requestJson(String username) {
+        return String.format("{\n" +
+                "  \"username\": \"%s\",\n" +
+                "  \"auth_config\": {\n" +
+                "      \"id\": \"file\",\n" +
+                "      \"configuration\": {\n" +
+                "        \"PasswordFilePath\": \"/var/etc/password.properties\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "}", username);
+    }
+}


### PR DESCRIPTION
* 'does-user-exists' plugin-extension call is introduced as part
 of Authorization extension version v2.
* 'does-user-exists' call returns 200 when the user exists in the
  password file and returns 404 if the user does not exists in
  the password file.

--- 
Required changes at core side: https://github.com/gocd/gocd/pull/5809