### PR TITLE
Updating to github actions and Java 15

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -1,0 +1,18 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Testing For PRs
+
+on: [ pull_request ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: Build with Gradle
+        run: ./gradlew assemble check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Create Stable Release
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      prerelease:
+        description: 'The release should be an experimental release'
+        default: 'NO'
+        required: true
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_USER:  "gocd"
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      PRERELEASE:   "${{ github.event.inputs.prerelease }}"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: Release
+        run: ./gradlew verifyExpRelease githubRelease

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -1,0 +1,36 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Test and Build
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: Test with Gradle
+        run: ./gradlew assemble check
+  previewGithubRelease:
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_USER:  "gocd-contrib"
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: Test with Gradle
+        run: ./gradlew githubRelease

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ apply from: "https://raw.githubusercontent.com/gocd/gocd-plugin-gradle-task-help
 
 gocdPlugin {
   id = 'cd.go.authentication.passwordfile'
-  pluginVersion = '2.0.1'
-  goCdVersion = '18.1.0'
+  pluginVersion = '2.1.0'
+  goCdVersion = '20.9.0'
   name = 'Password File Authentication Plugin for GoCD'
   description = 'GoCD Authorization plugin for file based password authentication'
   vendorName = 'ThoughtWorks, Inc.'


### PR DESCRIPTION
Wait for https://github.com/gocd/gocd-plugin-gradle-task-helpers/pull/8

 - Added workflows for github actions to test the PRs, master and create an exp release
 - Also added a manual workflow which when triggered will check if an exp release is present for the current master. If yes, will create a stable release.
 - Updated the min GoCD version to 20.9.0 as Java 15 support was introduced in the same.